### PR TITLE
Added GoQuorum private transaction serializer

### DIFF
--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
@@ -21,8 +21,10 @@ import tech.pegasys.ethsigner.core.jsonrpc.JsonRpcRequest;
 import tech.pegasys.ethsigner.core.jsonrpc.exception.JsonRpcException;
 import tech.pegasys.ethsigner.core.requesthandler.JsonRpcRequestHandler;
 import tech.pegasys.ethsigner.core.requesthandler.VertxRequestTransmitterFactory;
+import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction.GoQuorumPrivateTransaction;
 import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction.Transaction;
 import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction.TransactionFactory;
+import tech.pegasys.ethsigner.core.signing.GoQuorumPrivateTransactionSerializer;
 import tech.pegasys.ethsigner.core.signing.TransactionSerializer;
 import tech.pegasys.signers.secp256k1.api.Signer;
 
@@ -80,16 +82,20 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
       return;
     }
 
-    final TransactionSerializer transactionSerializer =
-        new TransactionSerializer(signer.get(), chainId);
-    sendTransaction(transaction, transactionSerializer, context, request);
+    sendTransaction(transaction, context, signer.get(), request);
   }
 
   private void sendTransaction(
       final Transaction transaction,
-      final TransactionSerializer transactionSerializer,
       final RoutingContext routingContext,
+      final Signer signer,
       final JsonRpcRequest request) {
+
+    final TransactionSerializer transactionSerializer =
+        transaction instanceof GoQuorumPrivateTransaction
+            ? new GoQuorumPrivateTransactionSerializer(signer, chainId)
+            : new TransactionSerializer(signer, chainId);
+
     final TransactionTransmitter transmitter =
         createTransactionTransmitter(transaction, transactionSerializer, routingContext, request);
     transmitter.send();

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/GoQuorumPrivateTransaction.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/GoQuorumPrivateTransaction.java
@@ -24,8 +24,6 @@ import java.util.List;
 
 import com.google.common.base.MoreObjects;
 import io.vertx.core.json.JsonObject;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.web3j.crypto.RawTransaction;
 import org.web3j.crypto.Sign.SignatureData;
@@ -36,8 +34,6 @@ import org.web3j.rlp.RlpType;
 import org.web3j.utils.Base64String;
 
 public class GoQuorumPrivateTransaction extends EthTransaction {
-
-  private static final Logger LOG = LogManager.getLogger();
 
   private final List<Base64String> privateFor;
   private final EnclaveLookupIdProvider enclaveLookupIdProvider;
@@ -118,7 +114,6 @@ public class GoQuorumPrivateTransaction extends EthTransaction {
   @Override
   public byte[] rlpEncode(final SignatureData signatureData) {
     final RawTransaction rawTransaction = createTransaction();
-    LOG.info("RLP encoding raw tx ");
     final List<RlpType> values = TransactionEncoder.asRlpValues(rawTransaction, signatureData);
     final RlpList rlpList = new RlpList(values);
     return RlpEncoder.encode(rlpList);

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/GoQuorumPrivateTransaction.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/GoQuorumPrivateTransaction.java
@@ -13,7 +13,6 @@
 package tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction;
 
 import static tech.pegasys.ethsigner.core.jsonrpc.RpcUtil.JSON_RPC_VERSION;
-import static tech.pegasys.ethsigner.core.signing.GoQuorumPrivateTransactionSerializer.getGoQuorumVValue;
 
 import tech.pegasys.ethsigner.core.jsonrpc.EthSendTransactionJsonParameters;
 import tech.pegasys.ethsigner.core.jsonrpc.JsonRpcRequest;
@@ -120,11 +119,7 @@ public class GoQuorumPrivateTransaction extends EthTransaction {
   public byte[] rlpEncode(final SignatureData signatureData) {
     final RawTransaction rawTransaction = createTransaction();
     LOG.info("RLP encoding raw tx ");
-    final byte[] v = signatureData.getV();
-    final SignatureData fixedSignatureData =
-        new SignatureData(getGoQuorumVValue(v), signatureData.getR(), signatureData.getS());
-    LOG.info("V value " + fixedSignatureData.getV()[0]);
-    final List<RlpType> values = TransactionEncoder.asRlpValues(rawTransaction, fixedSignatureData);
+    final List<RlpType> values = TransactionEncoder.asRlpValues(rawTransaction, signatureData);
     final RlpList rlpList = new RlpList(values);
     return RlpEncoder.encode(rlpList);
   }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/signing/GoQuorumPrivateTransactionSerializer.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/signing/GoQuorumPrivateTransactionSerializer.java
@@ -40,6 +40,8 @@ public class GoQuorumPrivateTransactionSerializer extends TransactionSerializer 
   }
 
   public static byte[] getGoQuorumVValue(byte[] v) {
+    // The current v has a value of 27 or 28,
+    // and we need to change that to 37 or 38 for GoQuorum private tx
     if (v[v.length - 1] == (byte) 28) {
       return new byte[] {38};
     } else {

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/signing/GoQuorumPrivateTransactionSerializer.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/signing/GoQuorumPrivateTransactionSerializer.java
@@ -16,14 +16,10 @@ import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction.Tr
 import tech.pegasys.signers.secp256k1.api.Signature;
 import tech.pegasys.signers.secp256k1.api.Signer;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.web3j.crypto.Sign.SignatureData;
 import org.web3j.utils.Numeric;
 
 public class GoQuorumPrivateTransactionSerializer extends TransactionSerializer {
-
-  private static final Logger LOG = LogManager.getLogger();
 
   public GoQuorumPrivateTransactionSerializer(Signer signer, long chainId) {
     super(signer, chainId);
@@ -31,30 +27,23 @@ public class GoQuorumPrivateTransactionSerializer extends TransactionSerializer 
 
   @Override
   public String serialize(final Transaction transaction) {
-    LOG.info("ignoring the chainId ");
-    LOG.info("tx.sender " + transaction.sender());
-
-    // TODO does signing an empty byte [] give the right thing?
-    final Signature signature = signer.sign(new byte[] {});
-
-    LOG.info("signing bytes " + " with signature V " + signature.getV());
+    final byte[] bytesToSign = transaction.rlpEncode(null);
+    final Signature signature = signer.sign(bytesToSign);
 
     byte[] newV = (getGoQuorumVValue(signature.getV().toByteArray()));
-
-    LOG.info("signing bytes " + " with signature R " + signature.getR());
-    LOG.info("signing bytes " + " with signature S " + signature.getS());
-    LOG.info("signing bytes " + " with NEW signature V " + newV);
 
     final SignatureData web3jSignature =
         new SignatureData(newV, signature.getR().toByteArray(), signature.getS().toByteArray());
 
     final byte[] serializedBytes = transaction.rlpEncode(web3jSignature);
-    LOG.info("made serialized bytes " + Numeric.toHexString(serializedBytes));
     return Numeric.toHexString(serializedBytes);
   }
 
   public static byte[] getGoQuorumVValue(byte[] v) {
-    LOG.info("using " + v + " to get GoQuorum V ");
-    return ((v[v.length - 1] & 1) == 1) ? new byte[] {38} : new byte[] {37};
+    if (v[v.length - 1] == (byte) 28) {
+      return new byte[] {38};
+    } else {
+      return new byte[] {37};
+    }
   }
 }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/signing/TransactionSerializer.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/signing/TransactionSerializer.java
@@ -16,8 +16,6 @@ import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction.Tr
 import tech.pegasys.signers.secp256k1.api.Signature;
 import tech.pegasys.signers.secp256k1.api.Signer;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.web3j.crypto.Keys;
 import org.web3j.crypto.Sign.SignatureData;
 import org.web3j.crypto.TransactionEncoder;
@@ -25,10 +23,8 @@ import org.web3j.utils.Numeric;
 
 public class TransactionSerializer {
 
-  private static final Logger LOG = LogManager.getLogger();
-
   protected final Signer signer;
-  private final long chainId;
+  protected final long chainId;
 
   public TransactionSerializer(final Signer signer, final long chainId) {
     this.signer = signer;
@@ -48,8 +44,6 @@ public class TransactionSerializer {
 
     final SignatureData eip155Signature =
         TransactionEncoder.createEip155SignatureData(web3jSignature, chainId);
-    LOG.info("Made an EIP1551 signature with V " + eip155Signature.getV());
-
     final byte[] serializedBytes = transaction.rlpEncode(eip155Signature);
     return Numeric.toHexString(serializedBytes);
   }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/signing/TransactionSerializer.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/signing/TransactionSerializer.java
@@ -44,7 +44,7 @@ public class TransactionSerializer {
 
     final SignatureData eip155Signature =
         TransactionEncoder.createEip155SignatureData(web3jSignature, chainId);
-    
+
     final byte[] serializedBytes = transaction.rlpEncode(eip155Signature);
     return Numeric.toHexString(serializedBytes);
   }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/signing/TransactionSerializer.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/signing/TransactionSerializer.java
@@ -44,6 +44,7 @@ public class TransactionSerializer {
 
     final SignatureData eip155Signature =
         TransactionEncoder.createEip155SignatureData(web3jSignature, chainId);
+    
     final byte[] serializedBytes = transaction.rlpEncode(eip155Signature);
     return Numeric.toHexString(serializedBytes);
   }


### PR DESCRIPTION
The signature is handled differently for GoQuorum private transactions. Specifically the chainId is ignored and the v value is either 37 or 38. 