### PR TITLE
Resolve and publish to cloudsmith

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,9 +174,6 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run:
-          name: "Which cloudsmith user is being used?"
-          command: echo $CLOUDSMITH_USER
-      - run:
           name: Publish
           command: |
             ./gradlew --no-daemon --parallel cloudSmithUpload
@@ -241,7 +238,7 @@ workflows:
             - acceptanceTests
           context:
             - dockerhub-quorumengineering-ro   
-            - quorum-gradle                 
+            - cloudsmith-protocols
       - publishDocker:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
       - run:
           name: Publish
           command: |
-            ./gradlew --no-daemon --parallel cloudSmithUpload
+            ./gradlew --no-daemon --parallel cloudSmithUpload publish
       - notify
       
   publishDocker:

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,6 @@ allprojects {
     jcenter()
     mavenCentral()
     maven { url "https://artifacts.consensys.net/public/maven/maven/" }
-    maven { url "https://consensys.bintray.com/pegasys-repo" }
   }
 
   dependencies { errorprone("com.google.errorprone:error_prone_core") }

--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ allprojects {
   repositories {
     jcenter()
     mavenCentral()
-    //TODO: Update the cloudsmith maven repo once created - for internal libraries such as Signers
+    maven { url "https://artifacts.consensys.net/public/maven/maven/" }
     maven { url "https://consensys.bintray.com/pegasys-repo" }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ if (!JavaVersion.current().java11Compatible) {
   "  Detected version ${JavaVersion.current()}")
 }
 
+def cloudsmithUser = project.hasProperty('cloudsmithUser') ? project.property('cloudsmithUser') : System.getenv('CLOUDSMITH_USER')
+def cloudsmithKey = project.hasProperty('cloudsmithApiKey') ? project.property('cloudsmithApiKey') : System.getenv('CLOUDSMITH_API_KEY')
+
 group = 'tech.pegasys.' + repositoryName
 
 defaultTasks 'build', 'checkLicenses', 'javadoc'
@@ -233,8 +236,19 @@ subprojects {
     apply plugin: 'maven-publish'
 
     publishing {
+      repositories {
+        maven {
+          name = "cloudsmith"
+          url = "https://api-g.cloudsmith.io/maven/consensys/maven/"
+          credentials {
+            username = cloudsmithUser
+            password = cloudsmithKey
+          }
+        }
+      }
       publications {
         mavenJava(MavenPublication) {
+          artifactId calculateJarName(project)
           groupId String.format("tech.pegasys.%s.internal", repositoryName)
           version "${project.version}"
           from components.java
@@ -246,7 +260,7 @@ subprojects {
           }
           pom {
             name = projectName + " -  ${project.name}"
-            url = 'http://github.com/PegaSysEng/' + repositoryName
+            url = 'http://github.com/ConsenSys/' + repositoryName
             licenses {
               license {
                 name = 'The Apache License, Version 2.0'
@@ -254,10 +268,10 @@ subprojects {
               }
             }
             scm {
-              def hostPath = 'github.com/PegasysEng/' + repositoryName + '.git'
+              def hostPath = 'github.com/ConsenSys/' + repositoryName + '.git'
               connection = 'scm:git:git://' + hostPath
               developerConnection = 'scm:git:ssh://' + hostPath
-              url = 'https://github.com/PegaSysEng/' + repositoryName
+              url = 'https://github.com/ConsenSys/' + repositoryName
             }
           }
         }
@@ -621,3 +635,16 @@ task cloudsmithUpload {
 }
 
 afterReleaseBuild.dependsOn cloudsmithUpload
+
+def calculateJarName(Project project) {
+  def jarName = project.name
+  def parent = project.parent
+
+  while (parent != null) {
+    if (parent != rootProject) {
+      jarName = parent.name + '-' + jarName
+    }
+    parent = parent.parent
+  }
+  return jarName
+}

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -68,7 +68,7 @@ dependencyManagement {
     dependency 'org.web3j:core:4.5.14'
     dependency 'org.web3j:crypto:4.5.14'
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.4') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.16') {
       entry 'keystorage-hashicorp'
       entry 'signing-secp256k1-api'
       entry 'signing-secp256k1-impl'

--- a/scripts/cloudsmith-upload.sh
+++ b/scripts/cloudsmith-upload.sh
@@ -17,7 +17,7 @@ if [[ $VERSION == *"SNAPSHOT"* ]]; then
   REPUBLISH="--republish"
 fi
 
-if [ -z ${CLOUDSMITH_USER+x} ]; then echo "CLOUDSMITH_USER is unset"; else echo "CLOUDSMITH_USER is set to '$CLOUDSMITH_USER'"; fi
+if [ -z ${CLOUDSMITH_USER+x} ]; then echo "CLOUDSMITH_USER is unset."; else echo "CLOUDSMITH_USER is set."; fi
 
 # cloudsmith cli setup
 ENV_DIR=./build/tmp/cloudsmith-env


### PR DESCRIPTION
- The latest version of signers resolves from cloudsmith
- EthSigner module jars are published to cloudsmith as they are used by Besu AT.