### PR TITLE
fixing NONCE_TOO_LOW retries and adding retries for ETH_SEND_TX_REPLACEMENT_UNDERPRICED

### DIFF
--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/model/response/EthResponseFactory.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/model/response/EthResponseFactory.java
@@ -76,7 +76,6 @@ public class EthResponseFactory {
   public EthNodeResponse ethNode(final JsonRpcError error) {
     final JsonRpcErrorResponse errorResponse = new JsonRpcErrorResponse(DEFAULT_ID, error);
 
-    return new EthNodeResponse(
-        NO_HEADERS, Json.encode(errorResponse), HttpResponseStatus.BAD_REQUEST);
+    return new EthNodeResponse(NO_HEADERS, Json.encode(errorResponse), HttpResponseStatus.OK);
   }
 }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/RetryingTransactionTransmitter.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/RetryingTransactionTransmitter.java
@@ -22,7 +22,6 @@ import tech.pegasys.ethsigner.core.signing.TransactionSerializer;
 
 import java.util.Map.Entry;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.ext.web.RoutingContext;
 
 public class RetryingTransactionTransmitter extends TransactionTransmitter {
@@ -42,8 +41,7 @@ public class RetryingTransactionTransmitter extends TransactionTransmitter {
   @Override
   public void handleResponse(
       final Iterable<Entry<String, String>> headers, final int statusCode, final String body) {
-    if (statusCode != HttpResponseStatus.OK.code()
-        && retryMechanism.responseRequiresRetry(statusCode, body)) {
+    if (retryMechanism.responseRequiresRetry(statusCode, body)) {
       if (retryMechanism.retriesAvailable()) {
         retryMechanism.incrementRetries();
         send();

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
@@ -44,7 +44,7 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
   private final TransactionFactory transactionFactory;
   private final VertxRequestTransmitterFactory vertxTransmitterFactory;
 
-  private static final int MAX_NONCE_RETRIES = 5;
+  private static final int MAX_NONCE_RETRIES = 10;
 
   public SendTransactionHandler(
       final long chainId,


### PR DESCRIPTION
NONCE_TOO_LOW retries broke because HTML return codes have changed. Also added retries for ETH_SEND_TX_REPLACEMENT_UNDERPRICED errors.

Signed-off-by: Stefan Pingel <stefan.pingel@consensys.net>