### PR TITLE
retry if known transaction

### DIFF
--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/NonceTooLowRetryMechanism.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/NonceTooLowRetryMechanism.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.ethsigner.core.requesthandler.sendtransaction;
 
+import static tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError.ETH_SEND_TX_ALREADY_KNOWN;
 import static tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError.ETH_SEND_TX_REPLACEMENT_UNDERPRICED;
 import static tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError.NONCE_TOO_LOW;
 
@@ -42,10 +43,11 @@ public class NonceTooLowRetryMechanism extends RetryMechanism {
       if (NONCE_TOO_LOW.equals(errorResponse.getError())) {
         LOG.info("Nonce too low, resend required for {}.", errorResponse.getId());
         return true;
-      } else if (ETH_SEND_TX_REPLACEMENT_UNDERPRICED.equals(errorResponse.getError())) {
+      } else if (ETH_SEND_TX_ALREADY_KNOWN.equals(errorResponse.getError())
+          || ETH_SEND_TX_REPLACEMENT_UNDERPRICED.equals(errorResponse.getError())) {
         LOG.info(
             "Besu returned \"{}\", which means that a Tx with the same nonce is in the transaction pool, resend required for {}.",
-            ETH_SEND_TX_REPLACEMENT_UNDERPRICED,
+            errorResponse.getError(),
             errorResponse.getId());
         return true;
       }

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/NonceTooLowRetryMechanismTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/NonceTooLowRetryMechanismTest.java
@@ -41,6 +41,44 @@ public class NonceTooLowRetryMechanismTest {
   }
 
   @Test
+  public void retryIsRequiredIfErrorIsNonceTooLow() {
+    when(httpResponse.statusCode()).thenReturn(HttpResponseStatus.OK.code());
+
+    final JsonRpcErrorResponse errorResponse = new JsonRpcErrorResponse(JsonRpcError.NONCE_TOO_LOW);
+
+    assertThat(
+            retryMechanism.responseRequiresRetry(
+                httpResponse.statusCode(), Json.encode(errorResponse)))
+        .isTrue();
+  }
+
+  @Test
+  public void retryIsRequiredIfErrorIsKnownTransaction() {
+    when(httpResponse.statusCode()).thenReturn(HttpResponseStatus.OK.code());
+
+    final JsonRpcErrorResponse errorResponse =
+        new JsonRpcErrorResponse(JsonRpcError.ETH_SEND_TX_ALREADY_KNOWN);
+
+    assertThat(
+            retryMechanism.responseRequiresRetry(
+                httpResponse.statusCode(), Json.encode(errorResponse)))
+        .isTrue();
+  }
+
+  @Test
+  public void retryIsRequiredIfErrorIsReplacementTransactionUnderpriced() {
+    when(httpResponse.statusCode()).thenReturn(HttpResponseStatus.OK.code());
+
+    final JsonRpcErrorResponse errorResponse =
+        new JsonRpcErrorResponse(JsonRpcError.ETH_SEND_TX_REPLACEMENT_UNDERPRICED);
+
+    assertThat(
+            retryMechanism.responseRequiresRetry(
+                httpResponse.statusCode(), Json.encode(errorResponse)))
+        .isTrue();
+  }
+
+  @Test
   public void retryIsNotRequiredIfErrorIsNotNonceTooLow() {
     when(httpResponse.statusCode()).thenReturn(HttpResponseStatus.BAD_REQUEST.code());
 


### PR DESCRIPTION
Treat "known transaction" error the same as "replacement tx underpriced".

Without this change, `public_smart_contract_event.spec` test fails. With this change, it passes.

Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>