### PR TITLE
Upgrade signers to 1.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## ...Next Version...
 
+### Breaking Changes
+- Upgrade to signers 1.0.18 removes support for deprecated SECP256K1 curve.
+
 ### Features Added
 
 - Add publishing to docker namespace "consensys/ethsigner"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## ...Next Version...
+### Features Added
+- Upgrade to signers 1.0.19 allows empty password files to be read when creating a Signer.
 
 ### Breaking Changes
-- Upgrade to signers 1.0.18 removes support for deprecated SECP256K1 curve.
+- Upgrade to signers 1.0.19 removes support for deprecated SECP256K1 curve in Azure remote signing.
 
 ### Features Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 ### Breaking Changes
 - Upgrade to signers 1.0.19 removes support for deprecated SECP256K1 curve in Azure remote signing [#386](https://github.com/ConsenSys/ethsigner/pull/386)
 
+### Bugs Fixed
+- Upgrade web3j to latest version for fix to handle large chainids in eip155 transactions [#382](https://github.com/ConsenSys/ethsigner/pull/382)
+
 ### Features Added
 - Add validation for GoQuorum transactions with value [#377](https://github.com/ConsenSys/ethsigner/pull/377)
-- Upgrade web3j to latest version for fix to handle large chainids in eip155 transactions [#382](https://github.com/ConsenSys/ethsigner/pull/382)
 - Add publishing to docker namespace "consensys/ethsigner" and deprecate docker namespace "consensys/quorum-ethsigner" [#384](https://github.com/ConsenSys/ethsigner/issues/384)
 - Upgrade to signers 1.0.19 allows empty password files to be read when creating a Signer [#372](https://github.com/ConsenSys/ethsigner/issues/372)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## ...Next Version...
 ### Breaking Changes
-- Upgrade to signers 1.0.19 removes support for deprecated SECP256K1 curve in Azure remote signing https://github.com/ConsenSys/ethsigner/pull/386
+- Upgrade to signers 1.0.19 removes support for deprecated SECP256K1 curve in Azure remote signing [#386](https://github.com/ConsenSys/ethsigner/pull/386)
 
 ### Features Added
-- Add validation for GoQuorum transactions with value https://github.com/ConsenSys/ethsigner/pull/377
-- Upgrade web3j to latest version for fix to handle large chainids in eip155 transactions https://github.com/ConsenSys/ethsigner/pull/382
-- Add publishing to docker namespace "consensys/ethsigner" and deprecate docker namespace "consensys/quorum-ethsigner" https://github.com/ConsenSys/ethsigner/issues/384
-- Upgrade to signers 1.0.19 allows empty password files to be read when creating a Signer https://github.com/ConsenSys/ethsigner/issues/372
+- Add validation for GoQuorum transactions with value [#377](https://github.com/ConsenSys/ethsigner/pull/377)
+- Upgrade web3j to latest version for fix to handle large chainids in eip155 transactions [#382](https://github.com/ConsenSys/ethsigner/pull/382)
+- Add publishing to docker namespace "consensys/ethsigner" and deprecate docker namespace "consensys/quorum-ethsigner" [#384](https://github.com/ConsenSys/ethsigner/issues/384)
+- Upgrade to signers 1.0.19 allows empty password files to be read when creating a Signer [#372](https://github.com/ConsenSys/ethsigner/issues/372)
 
 ## 21.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,14 @@
 # Changelog
 
 ## ...Next Version...
-### Features Added
-- Upgrade to signers 1.0.19 allows empty password files to be read when creating a Signer.
-
 ### Breaking Changes
-- Upgrade to signers 1.0.19 removes support for deprecated SECP256K1 curve in Azure remote signing.
+- Upgrade to signers 1.0.19 removes support for deprecated SECP256K1 curve in Azure remote signing https://github.com/ConsenSys/ethsigner/pull/386
 
 ### Features Added
-
-- Add publishing to docker namespace "consensys/ethsigner"
-- Deprecating docker namespace "consensys/quorum-ethsigner"
+- Add validation for GoQuorum transactions with value https://github.com/ConsenSys/ethsigner/pull/377
+- Upgrade web3j to latest version for fix to handle large chainids in eip155 transactions https://github.com/ConsenSys/ethsigner/pull/382
+- Add publishing to docker namespace "consensys/ethsigner" and deprecate docker namespace "consensys/quorum-ethsigner" https://github.com/ConsenSys/ethsigner/issues/384
+- Upgrade to signers 1.0.19 allows empty password files to be read when creating a Signer https://github.com/ConsenSys/ethsigner/issues/372
 
 ## 21.3.2
 

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/signer/TransactionSignerParamsSupplier.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/signer/TransactionSignerParamsSupplier.java
@@ -83,7 +83,7 @@ public class TransactionSignerParamsSupplier {
       params.add("--key-name");
       params.add("TestKey");
       params.add("--key-version");
-      params.add("7c01fe58d68148bba5824ce418241092");
+      params.add("");
       params.add("--client-id");
       params.add(System.getenv("ETHSIGNER_AZURE_CLIENT_ID"));
       params.add("--client-secret-path");

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/signer/TransactionSignerParamsSupplier.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/signer/TransactionSignerParamsSupplier.java
@@ -81,7 +81,7 @@ public class TransactionSignerParamsSupplier {
       params.add("--key-vault-name");
       params.add(azureKeyVault);
       params.add("--key-name");
-      params.add("TestKey");
+      params.add("TestKey2");
       params.add("--key-version");
       params.add("");
       params.add("--client-id");

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/AzureBasedTomlLoadingAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/AzureBasedTomlLoadingAcceptanceTest.java
@@ -26,7 +26,7 @@ public class AzureBasedTomlLoadingAcceptanceTest extends MultiKeyAcceptanceTestB
   static final String clientId = System.getenv("ETHSIGNER_AZURE_CLIENT_ID");
   static final String clientSecret = System.getenv("ETHSIGNER_AZURE_CLIENT_SECRET");
   static final String tenantId = System.getenv("ETHSIGNER_AZURE_TENANT_ID");
-  static final String FILENAME = "fe3b557e8fb62b89f4916b721be55ceb828dbd73";
+  static final String FILENAME = "8c250253147a091cfcb7e9425022bcd03a329ce6";
   static final String AZURE_ETHEREUM_ADDRESS = "0x" + FILENAME;
 
   @BeforeAll

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/MultiKeyAcceptanceTestBase.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/MultiKeyAcceptanceTestBase.java
@@ -63,7 +63,7 @@ public class MultiKeyAcceptanceTestBase {
             .withQuotedString("type", "azure-signer")
             .withQuotedString("key-vault-name", "ethsignertestkey")
             .withQuotedString("key-name", "TestKey")
-            .withQuotedString("key-version", "7c01fe58d68148bba5824ce418241092")
+            .withQuotedString("key-version", "")
             .withQuotedString("client-id", clientId)
             .withQuotedString("client-secret", clientSecret)
             .withQuotedString("tenant-id", tenantId)

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/MultiKeyAcceptanceTestBase.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/MultiKeyAcceptanceTestBase.java
@@ -62,7 +62,7 @@ public class MultiKeyAcceptanceTestBase {
         new TomlStringBuilder("signing")
             .withQuotedString("type", "azure-signer")
             .withQuotedString("key-vault-name", "ethsignertestkey")
-            .withQuotedString("key-name", "TestKey")
+            .withQuotedString("key-name", "TestKey2")
             .withQuotedString("key-version", "")
             .withQuotedString("client-id", clientId)
             .withQuotedString("client-secret", clientSecret)

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/transactionsigning/MultiKeyAzureTransactionSignerAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/transactionsigning/MultiKeyAzureTransactionSignerAcceptanceTest.java
@@ -25,7 +25,9 @@ public class MultiKeyAzureTransactionSignerAcceptanceTest
   static final String clientId = System.getenv("ETHSIGNER_AZURE_CLIENT_ID");
   static final String clientSecret = System.getenv("ETHSIGNER_AZURE_CLIENT_SECRET");
   static final String tenantId = System.getenv("ETHSIGNER_AZURE_TENANT_ID");
-  static final String FILENAME = "fe3b557e8fb62b89f4916b721be55ceb828dbd73";
+  static final String FILENAME = "8c250253147a091cfcb7e9425022bcd03a329ce6";
+  private static final String AZURE_GENESIS_ACCOUNT_ONE_PUBLIC_KEY =
+      "0x8c250253147a091cfcb7e9425022bcd03a329ce6";
 
   @BeforeAll
   public static void checkAzureCredentials() {
@@ -44,6 +46,6 @@ public class MultiKeyAzureTransactionSignerAcceptanceTest
 
     setup(tomlDirectory);
 
-    performTransaction();
+    performTransaction(AZURE_GENESIS_ACCOUNT_ONE_PUBLIC_KEY);
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/transactionsigning/MultiKeyTransactionSigningAcceptanceTestBase.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/transactionsigning/MultiKeyTransactionSigningAcceptanceTestBase.java
@@ -62,17 +62,16 @@ public class MultiKeyTransactionSigningAcceptanceTestBase extends MultiKeyAccept
   }
 
   void performTransaction() {
+    performTransaction(richBenefactor().address());
+  }
+
+  void performTransaction(String ethAddress) {
     final BigInteger transferAmountWei = Convert.toWei("1.75", Unit.ETHER).toBigIntegerExact();
 
     final BigInteger startBalance = ethNode.accounts().balance(RECIPIENT);
     final Transaction transaction =
         Transaction.createEtherTransaction(
-            richBenefactor().address(),
-            null,
-            GAS_PRICE,
-            INTRINSIC_GAS,
-            RECIPIENT,
-            transferAmountWei);
+            ethAddress, null, GAS_PRICE, INTRINSIC_GAS, RECIPIENT, transferAmountWei);
 
     final String hash = ethSigner.transactions().submit(transaction);
     ethNode.transactions().awaitBlockContaining(hash);

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/signing/ValueTransferWithAzureAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/signing/ValueTransferWithAzureAcceptanceTest.java
@@ -16,7 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.ethsigner.tests.dsl.Gas.GAS_PRICE;
 import static tech.pegasys.ethsigner.tests.dsl.Gas.INTRINSIC_GAS;
 
-import tech.pegasys.ethsigner.tests.dsl.Account;
 import tech.pegasys.ethsigner.tests.dsl.node.Node;
 import tech.pegasys.ethsigner.tests.dsl.node.besu.BesuNodeConfig;
 import tech.pegasys.ethsigner.tests.dsl.node.besu.BesuNodeConfigBuilder;
@@ -37,6 +36,8 @@ import org.web3j.utils.Convert;
 public class ValueTransferWithAzureAcceptanceTest {
 
   private static final String RECIPIENT = "0x1b00ba00ca00bb00aa00bc00be00ac00ca00da00";
+  private static final String AZURE_GENESIS_ACCOUNT_ONE_PUBLIC_KEY =
+      "0x8c250253147a091cfcb7e9425022bcd03a329ce6";
 
   private static Node ethNode;
   private static Signer ethSigner;
@@ -80,10 +81,6 @@ public class ValueTransferWithAzureAcceptanceTest {
     }
   }
 
-  private Account richBenefactor() {
-    return ethSigner.accounts().richBenefactor();
-  }
-
   private Signer ethSigner() {
     return ethSigner;
   }
@@ -99,7 +96,7 @@ public class ValueTransferWithAzureAcceptanceTest {
     final BigInteger startBalance = ethNode().accounts().balance(RECIPIENT);
     final Transaction transaction =
         Transaction.createEtherTransaction(
-            richBenefactor().address(),
+            AZURE_GENESIS_ACCOUNT_ONE_PUBLIC_KEY,
             null,
             GAS_PRICE,
             INTRINSIC_GAS,

--- a/acceptance-tests/src/test/resources/eth_hash_2018.json
+++ b/acceptance-tests/src/test/resources/eth_hash_2018.json
@@ -36,6 +36,10 @@
       "privateKey": "ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f",
       "comment": "private key and this comment are ignored.  In a real chain, the private key should NOT be stored",
       "balance": "90000000000000000000000"
+    },
+    "8c250253147a091cfcb7e9425022bcd03a329ce6" : {
+      "comment": "azure public key",
+      "balance": "90000000000000000000000"
     }
   },
   "number": "0x0",

--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -98,6 +98,7 @@ downloadLicenses {
                   license('New BSD License', 'http://www.opensource.org/licenses/bsd-license.php')
           ],
           (bsd3Clause): [
+                  'BSD-3-Clause',
                   'BSD 3-Clause',
                   'BSD 3-Clause "New" or "Revised" License (BSD-3-Clause)',
                   '3-Clause BSD License',
@@ -162,7 +163,8 @@ downloadLicenses {
           (group('javax.xml.bind')): cddl1_1,
           (group('net.jcip')): apache,
           (group('net.java.dev.jna')): apache,
-          (group('com.sun.mail')): cddl
+          (group('com.sun.mail')): cddl,
+          (group('io.netty')): apache,
   ]
 }
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -70,7 +70,7 @@ dependencyManagement {
       entry 'crypto'
     }
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.18') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.19') {
       entry 'keystorage-hashicorp'
       entry 'signing-secp256k1-api'
       entry 'signing-secp256k1-impl'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -29,7 +29,7 @@ dependencyManagement {
 
     dependency 'io.rest-assured:rest-assured:4.3.1'
 
-    dependencySet(group: 'io.vertx', version: '3.9.1') {
+    dependencySet(group: 'io.vertx', version: '3.9.9') {
        entry 'vertx-codegen'
        entry 'vertx-core'
        entry 'vertx-unit'
@@ -70,7 +70,7 @@ dependencyManagement {
       entry 'crypto'
     }
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.17') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.18') {
       entry 'keystorage-hashicorp'
       entry 'signing-secp256k1-api'
       entry 'signing-secp256k1-impl'


### PR DESCRIPTION
Includes vertx upgrade and transitive azure key vault upgrade with breaking change to SECP256K1 curve.

Allows empty password files to be read.
Fixes https://github.com/ConsenSys/ethsigner/issues/372