### PR TITLE
Add netcat package in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl=7.68\.* \
+RUN apt-get update && apt-get install -y --no-install-recommends curl=7.68\.* netcat=1.2* \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
 -- k8 or docker-compose can use nc command for container healthcheck (See https://github.com/ConsenSys/quorum-acceptance-tests/pull/167).