### PR TITLE
jnr-unixsocket was excluded from wrong entry

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -76,10 +76,10 @@ dependencyManagement {
 
     dependencySet(group: 'org.web3j', version: '4.8.9') {
       entry 'besu'
-      entry 'core'
-      entry('crypto') {
+      entry ('core') {
         exclude group: 'com.github.jnr', name: 'jnr-unixsocket'
       }
+      entry 'crypto'
     }
 
     dependencySet(group: 'tech.pegasys.signers.internal', version: '2.0.0') {


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

jnr-unixsocket comes from web3j core not crypto
Now if I run `./gradlew -q dependencies` 
I get this output: 

     |    |    +--- org.web3j:core:4.8.9
     |    |    |    +--- org.web3j:abi:4.8.9
     |    |    |    |    \--- org.web3j:utils:4.8.9
     |    |    |    |         \--- org.bouncycastle:bcprov-jdk15on:1.68 -> 1.70
     |    |    |    +--- org.web3j:crypto:4.8.9
     |    |    |    |    +--- org.web3j:abi:4.8.9 (*)
     |    |    |    |    +--- org.web3j:rlp:4.8.9
     |    |    |    |    |    \--- org.web3j:utils:4.8.9 (*)
     |    |    |    |    +--- org.web3j:utils:4.8.9 (*)
     |    |    |    |    +--- org.slf4j:slf4j-api:1.7.30 -> 1.7.32
     |    |    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.10.0 -> 2.13.1 (*)
     |    |    |    +--- org.web3j:tuples:4.8.9
     |    |    |    +--- com.squareup.okhttp3:okhttp:4.9.0 -> 4.9.3

without this PR:

     |    |    +--- org.web3j:core:4.8.9
     |    |    |    +--- org.web3j:abi:4.8.9
     |    |    |    |    \--- org.web3j:utils:4.8.9
     |    |    |    |         \--- org.bouncycastle:bcprov-jdk15on:1.68 -> 1.70
     |    |    |    +--- org.web3j:crypto:4.8.9
     |    |    |    |    +--- org.web3j:abi:4.8.9 (*)
     |    |    |    |    +--- org.web3j:rlp:4.8.9
     |    |    |    |    |    \--- org.web3j:utils:4.8.9 (*)
     |    |    |    |    +--- org.web3j:utils:4.8.9 (*)
     |    |    |    |    +--- org.slf4j:slf4j-api:1.7.30 -> 1.7.32
     |    |    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.10.0 -> 2.13.1 (*)
     |    |    |    +--- org.web3j:tuples:4.8.9
     |    |    |    +--- com.github.jnr:jnr-unixsocket:0.21