### PR TITLE
[366] Update Ethsigner Default Metrics Port

### DIFF
--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -199,7 +199,7 @@ public class EthSignerBaseCommand implements Config, Runnable {
       paramLabel = PORT_FORMAT_HELP,
       description = "Port for the metrics exporter to listen on (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private final Integer metricsPort = 8546;
+  private final Integer metricsPort = 9546;
 
   @Option(
       names = {"--metrics-category", "--metrics-categories"},


### PR DESCRIPTION
One small change to change the default metrics port from 8546 to 9546. 

https://github.com/ConsenSys/ethsigner/issues/366