### PR TITLE
[#366] Updated default port to 9546

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Upcoming Release
+### Breaking Changes
+- Update Metrics service default port from 8546 to 9546. 
+
 ## 22.1.0
 ### Features Added
 - Updated Tuweni dependency to version 2.1.0 [#432](https://github.com/ConsenSys/ethsigner/pull/432)

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -199,7 +199,7 @@ public class EthSignerBaseCommand implements Config, Runnable {
       paramLabel = PORT_FORMAT_HELP,
       description = "Port for the metrics exporter to listen on (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private final Integer metricsPort = 8546;
+  private final Integer metricsPort = 9546;
 
   @Option(
       names = {"--metrics-category", "--metrics-categories"},


### PR DESCRIPTION
Update metrics service default port to 9546. See #366 