### PR TITLE
Create PR template with documentation section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
+<!-- https://github.com/ConsenSys/ethsigner/blob/master/CONTRIBUTING.md -->
+
+## PR Description
+
+## Fixed Issue(s)
+<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
+<!-- Example: "fixes #2" -->
+
+## Documentation
+
+- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.
+
+## Changelog
+
+- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


### PR DESCRIPTION

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
The `doc-change-required` label is used to indicate that documentation updates are required.

Created a template to use the `doc-change-required` label.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.