### PR TITLE
Include netcat in the docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
-RUN apt update && apt install -y --no-install-recommends curl iputils-ping net-tools \
+RUN apt update && apt install -y --no-install-recommends curl iputils-ping net-tools netcat \
  && apt clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Include netcat in the docker image so it can be used to perform a health check for terraform, kubernetes etc. Note that netcat is not included as part of the nettools package https://packages.ubuntu.com/impish/i386/net-tools/filelist.