### PR TITLE
Allow running docker image as user that's not ethsigner

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" "$JAVA_HOME/bin
          --compress=2 \
          --output /javaruntime
 
-FROM ubuntu:21.10
+FROM ubuntu:22.04
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
@@ -20,7 +20,8 @@ RUN apt update && apt install -y --no-install-recommends curl iputils-ping net-t
 
 # Add ethsigner user instead of using root (may bring backward incompatibility for previous directory mounts)
 RUN adduser --disabled-password --gecos "" --home /opt/ethsigner ethsigner && \
-    chown ethsigner:ethsigner /opt/ethsigner
+    chown ethsigner:ethsigner /opt/ethsigner && \
+    chmod 755 /opt/ethsigner
 USER ethsigner
 WORKDIR /opt/ethsigner
 


### PR DESCRIPTION
## PR Description

Updated docker image to use Ubuntu 22.04 as 21.10 (impish) isn't in repository any more: http://archive.ubuntu.com/ubuntu/dists/.

Changed permission flags of /opt/ethsigner to allow it to run in Kubernetes environment (that doesn't allow specifying user).

before:
```
drwxr-x--- 1 ethsigner ethsigner 4.0K Apr  5 04:48 ethsigner
```

after:
```
drwxr-xr-x 1 ethsigner ethsigner 4.0K Aug 10 08:22 ethsigner
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

see [discord](https://discord.com/channels/697535391594446898/907168742272798750/1002179604477378580)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
