### PR TITLE
Update to jackson-databind to address CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
   dependencies {
     // custom license-reporter used by com.github.jk1.dependency-license-report plugin
     classpath 'tech.pegasys.internal.license.reporter:license-reporter:1.0.1'
-    classpath 'org.owasp:dependency-check-gradle:6.5.3'
+    classpath 'org.owasp:dependency-check-gradle:7.2.1'
   }
 }
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -74,7 +74,7 @@ dependencyManagement {
       entry 'mockito-junit-jupiter'
     }
 
-    dependencySet(group: 'org.web3j', version: '4.9.1') {
+    dependencySet(group: 'org.web3j', version: '4.9.4') {
       entry 'besu'
       entry ('core') {
         exclude group: 'com.github.jnr', name: 'jnr-unixsocket'
@@ -94,7 +94,7 @@ dependencyManagement {
     dependency "org.hyperledger.besu.internal:metrics-core:${besuVersion}"
 
     // explicit declaring to override transitive dependencies with vulnerabilities
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.14.0-rc1'
     dependencySet(group: 'com.google.protobuf', version: '3.19.4') {
       entry 'protobuf-java'
       entry 'protobuf-java-util'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -74,7 +74,7 @@ dependencyManagement {
       entry 'mockito-junit-jupiter'
     }
 
-    dependencySet(group: 'org.web3j', version: '4.9.4') {
+    dependencySet(group: 'org.web3j', version: '4.9.1') {
       entry 'besu'
       entry ('core') {
         exclude group: 'com.github.jnr', name: 'jnr-unixsocket'


### PR DESCRIPTION
## PR Description
Update jackson-databind library to 2.14.0-rc1 to address [CVE-2022-42003](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-42003) and [CVE-2022-42004](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-42004)
