### PR TITLE
[474] Add proxy options to http client to use Ethsigner behind proxy

### DIFF
--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -219,6 +219,37 @@ public class EthSignerBaseCommand implements Config, Runnable {
       defaultValue = "localhost,127.0.0.1")
   private final AllowListHostsProperty metricsHostAllowList = new AllowListHostsProperty();
 
+  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
+  @Option(
+      names = {"--http-proxy-host"},
+      description = "Hostname for proxy connect, no proxy if null (default: null)",
+      paramLabel = HOST_FORMAT_HELP,
+      arity = "1")
+  private String httpProxyHost = null;
+
+  @Option(
+      names = {"--http-proxy-port"},
+      paramLabel = PORT_FORMAT_HELP,
+      description = "Port for proxy connect (default: 80)",
+      arity = "1")
+  private final Integer httpProxyPort = 80;
+
+  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
+  @Option(
+      names = {"--http-proxy-username"},
+      paramLabel = "<username>",
+      description = "Username for proxy connect, no authentication if null (default: null)",
+      arity = "1")
+  private String httpProxyUsername = null;
+
+  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
+  @Option(
+      names = {"--http-proxy-password"},
+      paramLabel = "<password>",
+      description = "Password for proxy connect, no authentication if null (default: null)",
+      arity = "1")
+  private String httpProxyPassword = null;
+
   @Override
   public Level getLogLevel() {
     return logLevel;
@@ -307,6 +338,26 @@ public class EthSignerBaseCommand implements Config, Runnable {
   }
 
   @Override
+  public String getHttpProxyHost() {
+    return httpProxyHost;
+  }
+
+  @Override
+  public Integer getHttpProxyPort() {
+    return httpProxyPort;
+  }
+
+  @Override
+  public String getHttpProxyUsername() {
+    return httpProxyUsername;
+  }
+
+  @Override
+  public String getHttpProxyPassword() {
+    return httpProxyPassword;
+  }
+
+  @Override
   public void run() {
     // validation is performed to simulate similar behavior as with ArgGroups.
     // ArgGroups are removed because of config-file and environment based default options
@@ -329,6 +380,10 @@ public class EthSignerBaseCommand implements Config, Runnable {
         .add("dataPath", dataPath)
         .add("clientTlsOptions", clientTlsOptions)
         .add("corsAllowedOrigins", rpcHttpCorsAllowedOrigins)
+        .add("httpProxyHost", httpProxyHost)
+        .add("httpProxyPort", httpProxyPort)
+        .add("httpProxyUsername", httpProxyUsername)
+        .add("httpProxyPassword", httpProxyPassword)
         .toString();
   }
 

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -221,14 +221,14 @@ public class EthSignerBaseCommand implements Config, Runnable {
 
   @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @Option(
-      names = {"--http-proxy-host"},
+      names = {"--downstream-http-proxy-host"},
       description = "Hostname for proxy connect, no proxy if null (default: null)",
       paramLabel = HOST_FORMAT_HELP,
       arity = "1")
   private String httpProxyHost = null;
 
   @Option(
-      names = {"--http-proxy-port"},
+      names = {"--downstream-http-proxy-port"},
       paramLabel = PORT_FORMAT_HELP,
       description = "Port for proxy connect (default: 80)",
       arity = "1")
@@ -236,7 +236,7 @@ public class EthSignerBaseCommand implements Config, Runnable {
 
   @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @Option(
-      names = {"--http-proxy-username"},
+      names = {"--downstream-http-proxy-username"},
       paramLabel = "<username>",
       description = "Username for proxy connect, no authentication if null (default: null)",
       arity = "1")
@@ -244,7 +244,7 @@ public class EthSignerBaseCommand implements Config, Runnable {
 
   @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @Option(
-      names = {"--http-proxy-password"},
+      names = {"--downstream-http-proxy-password"},
       paramLabel = "<password>",
       description = "Password for proxy connect, no authentication if null (default: null)",
       arity = "1")

--- a/ethsigner/commandline/src/test-support/java/tech/pegasys/ethsigner/CmdlineHelpers.java
+++ b/ethsigner/commandline/src/test-support/java/tech/pegasys/ethsigner/CmdlineHelpers.java
@@ -46,10 +46,10 @@ public class CmdlineHelpers {
     optionsMap.put("downstream-http-tls-keystore-password-file", "./test.pass");
     optionsMap.put("downstream-http-tls-ca-auth-enabled", Boolean.FALSE);
     optionsMap.put("downstream-http-tls-known-servers-file", "./test.txt");
-    optionsMap.put("http-proxy-host", "localhost");
-    optionsMap.put("http-proxy-port", 80);
-    optionsMap.put("http-proxy-username", "username");
-    optionsMap.put("http-proxy-password", "passwd");
+    optionsMap.put("downstream-http-proxy-host", "localhost");
+    optionsMap.put("downstream-http-proxy-port", 80);
+    optionsMap.put("downstream-http-proxy-username", "username");
+    optionsMap.put("downstream-http-proxy-password", "passwd");
     return optionsMap;
   }
 

--- a/ethsigner/commandline/src/test-support/java/tech/pegasys/ethsigner/CmdlineHelpers.java
+++ b/ethsigner/commandline/src/test-support/java/tech/pegasys/ethsigner/CmdlineHelpers.java
@@ -46,7 +46,10 @@ public class CmdlineHelpers {
     optionsMap.put("downstream-http-tls-keystore-password-file", "./test.pass");
     optionsMap.put("downstream-http-tls-ca-auth-enabled", Boolean.FALSE);
     optionsMap.put("downstream-http-tls-known-servers-file", "./test.txt");
-
+    optionsMap.put("http-proxy-host", "localhost");
+    optionsMap.put("http-proxy-port", 80);
+    optionsMap.put("http-proxy-username", "username");
+    optionsMap.put("http-proxy-password", "passwd");
     return optionsMap;
   }
 

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
@@ -101,6 +101,10 @@ class CommandlineParserTest {
     assertThat(tlsClientConstaints.getKnownClientsFile())
         .isEqualTo(Optional.of(new File("./known_clients")));
     assertThat(tlsClientConstaints.isCaAuthorizedClientAllowed()).isTrue();
+    assertThat(config.getHttpProxyHost()).isEqualTo("localhost");
+    assertThat(config.getHttpProxyPort()).isEqualTo(80);
+    assertThat(config.getHttpProxyUsername()).isEqualTo("username");
+    assertThat(config.getHttpProxyPassword()).isEqualTo("passwd");
 
     final Optional<ClientTlsOptions> downstreamTlsOptionsOptional = config.getClientTlsOptions();
     assertThat(downstreamTlsOptionsOptional.isPresent()).isTrue();
@@ -154,6 +158,18 @@ class CommandlineParserTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
+  void nonIntegerInputForHttpProxyPortShowsError(final boolean useConfigFile) {
+    final Map<String, Object> options = modifyOptionValue("http-proxy-port", "abc");
+    final List<String> args =
+        useConfigFile ? toConfigFileOptionsList(tempDir, options) : toOptionsList(options);
+    final boolean result = parser.parseCommandLine(args.toArray(String[]::new));
+    assertThat(result).isFalse();
+    assertThat(commandError.toString()).contains("--http-proxy-port", "'abc' is not an int");
+    assertThat(commandOutput.toString()).containsOnlyOnce(defaultUsageText);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
   void missingRequiredParamShowsAppropriateError(final boolean useConfigFile) {
     parseCommandLineWithMissingParamsShowsError(
         parser,
@@ -200,6 +216,29 @@ class CommandlineParserTest {
   void missingListenHostDefaultsToLoopback() {
     missingOptionalParameterIsValidAndMeetsDefault(
         "http-listen-host", config::getHttpListenHost, "127.0.0.1");
+  }
+
+  @Test
+  void missingHttpProxyHostDefaultsToNull() {
+    missingOptionalParameterIsValidAndMeetsDefault(
+        "http-proxy-host", config::getHttpProxyHost, null);
+  }
+
+  @Test
+  void missingHttpProxyPortDefaultsToLoopback() {
+    missingOptionalParameterIsValidAndMeetsDefault("http-proxy-port", config::getHttpProxyPort, 80);
+  }
+
+  @Test
+  void missingHttpProxyUsernameDefaultsToNull() {
+    missingOptionalParameterIsValidAndMeetsDefault(
+        "http-proxy-username", config::getHttpProxyUsername, null);
+  }
+
+  @Test
+  void missingHttpProxyPasswordDefaultsToNull() {
+    missingOptionalParameterIsValidAndMeetsDefault(
+        "http-proxy-password", config::getHttpProxyPassword, null);
   }
 
   @Test

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
@@ -159,12 +159,13 @@ class CommandlineParserTest {
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   void nonIntegerInputForHttpProxyPortShowsError(final boolean useConfigFile) {
-    final Map<String, Object> options = modifyOptionValue("http-proxy-port", "abc");
+    final Map<String, Object> options = modifyOptionValue("downstream-http-proxy-port", "abc");
     final List<String> args =
         useConfigFile ? toConfigFileOptionsList(tempDir, options) : toOptionsList(options);
     final boolean result = parser.parseCommandLine(args.toArray(String[]::new));
     assertThat(result).isFalse();
-    assertThat(commandError.toString()).contains("--http-proxy-port", "'abc' is not an int");
+    assertThat(commandError.toString())
+        .contains("--downstream-http-proxy-port", "'abc' is not an int");
     assertThat(commandOutput.toString()).containsOnlyOnce(defaultUsageText);
   }
 
@@ -221,24 +222,25 @@ class CommandlineParserTest {
   @Test
   void missingHttpProxyHostDefaultsToNull() {
     missingOptionalParameterIsValidAndMeetsDefault(
-        "http-proxy-host", config::getHttpProxyHost, null);
+        "downstream-http-proxy-host", config::getHttpProxyHost, null);
   }
 
   @Test
   void missingHttpProxyPortDefaultsToLoopback() {
-    missingOptionalParameterIsValidAndMeetsDefault("http-proxy-port", config::getHttpProxyPort, 80);
+    missingOptionalParameterIsValidAndMeetsDefault(
+        "downstream-http-proxy-port", config::getHttpProxyPort, 80);
   }
 
   @Test
   void missingHttpProxyUsernameDefaultsToNull() {
     missingOptionalParameterIsValidAndMeetsDefault(
-        "http-proxy-username", config::getHttpProxyUsername, null);
+        "downstream-http-proxy-username", config::getHttpProxyUsername, null);
   }
 
   @Test
   void missingHttpProxyPasswordDefaultsToNull() {
     missingOptionalParameterIsValidAndMeetsDefault(
-        "http-proxy-password", config::getHttpProxyPassword, null);
+        "downstream-http-proxy-password", config::getHttpProxyPassword, null);
   }
 
   @Test

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/WebClientOptionsFactory.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/WebClientOptionsFactory.java
@@ -26,8 +26,12 @@ import java.util.Optional;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.ext.web.client.WebClientOptions;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 class WebClientOptionsFactory {
+  private static final Logger LOG = LogManager.getLogger();
+
   public WebClientOptions createWebClientOptions(final Config config) {
     final WebClientOptions clientOptions =
         new WebClientOptions()
@@ -42,9 +46,15 @@ class WebClientOptionsFactory {
 
   private static Optional<ProxyOptions> proxyOptions() {
     var proxyHost = System.getProperty("http.proxyHost", "none");
-    var proxyPort = Integer.valueOf(System.getProperty("http.proxyPort", "80"));
     if ("none".equalsIgnoreCase(proxyHost)) {
       return Optional.empty();
+    }
+    int proxyPort;
+    try {
+      proxyPort = Integer.valueOf(System.getProperty("http.proxyPort", "80"));
+    } catch (NumberFormatException nfe) {
+      LOG.warn("Error reading proxy port (defaulting to 80) : ", nfe);
+      proxyPort = 80;
     }
     var proxyOptions = new ProxyOptions();
     proxyOptions.setHost(proxyHost);

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/WebClientOptionsFactory.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/WebClientOptionsFactory.java
@@ -53,7 +53,7 @@ class WebClientOptionsFactory {
     try {
       proxyPort = Integer.valueOf(System.getProperty("http.proxyPort", "80"));
     } catch (NumberFormatException nfe) {
-      LOG.warn("Error reading proxy port (defaulting to 80) : ", nfe);
+      LOG.warn("Error reading proxy port : defaulting to 80");
       proxyPort = 80;
     }
     var proxyOptions = new ProxyOptions();

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/WebClientOptionsFactory.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/WebClientOptionsFactory.java
@@ -59,6 +59,14 @@ class WebClientOptionsFactory {
     var proxyOptions = new ProxyOptions();
     proxyOptions.setHost(proxyHost);
     proxyOptions.setPort(proxyPort);
+    var proxyUsername = System.getProperty("http.proxyUser", "none");
+    var proxyPassword = System.getProperty("http.proxyPassword", "none");
+    if (!"none".equalsIgnoreCase(proxyUsername)) {
+      proxyOptions.setUsername(proxyUsername);
+      if (!"none".equalsIgnoreCase(proxyPassword)) {
+        proxyOptions.setPassword(proxyPassword);
+      }
+    }
     return Optional.of(proxyOptions);
   }
 

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/WebClientOptionsFactory.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/WebClientOptionsFactory.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import io.vertx.core.net.PfxOptions;
+import io.vertx.core.net.ProxyOptions;
 import io.vertx.ext.web.client.WebClientOptions;
 
 class WebClientOptionsFactory {
@@ -32,10 +33,23 @@ class WebClientOptionsFactory {
         new WebClientOptions()
             .setDefaultPort(config.getDownstreamHttpPort())
             .setDefaultHost(config.getDownstreamHttpHost())
-            .setTryUseCompression(true);
+            .setTryUseCompression(true)
+            .setProxyOptions(proxyOptions().orElse(null));
 
     applyTlsOptions(clientOptions, config);
     return clientOptions;
+  }
+
+  private static Optional<ProxyOptions> proxyOptions() {
+    var proxyHost = System.getProperty("http.proxyHost", "none");
+    var proxyPort = Integer.valueOf(System.getProperty("http.proxyPort", "80"));
+    if ("none".equalsIgnoreCase(proxyHost)) {
+      return Optional.empty();
+    }
+    var proxyOptions = new ProxyOptions();
+    proxyOptions.setHost(proxyHost);
+    proxyOptions.setPort(proxyPort);
+    return Optional.of(proxyOptions);
   }
 
   private void applyTlsOptions(final WebClientOptions webClientOptions, final Config config) {

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/config/Config.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/config/Config.java
@@ -60,4 +60,12 @@ public interface Config {
   Set<MetricCategory> getMetricCategories();
 
   List<String> getMetricsHostAllowList();
+
+  String getHttpProxyHost();
+
+  Integer getHttpProxyPort();
+
+  String getHttpProxyUsername();
+
+  String getHttpProxyPassword();
 }


### PR DESCRIPTION
## PR Description
Add configuration to the vertx http client used by Ethsigner to access blockchain node behind a proxy.

## Fixed Issue(s)
fixes #474 

## Documentation

A change in the documentation should be made to use config variables for proxy : 
--downstream-http-proxy-host : Hostname for proxy connect, no proxy if null (default: null)
--downstream-http-proxy-port : Port for proxy connect (default: 80)
--downstream-http-proxy-username : Username for proxy connect, no authentication if null (default: null)
--downstream-http-proxy-password : Password for proxy connect, no authentication if null (default: null)