### PR TITLE
Update dependency-check-gradle plugin to 7.4.4 to fix error updating CVE-2020-36569

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
   dependencies {
     // custom license-reporter used by com.github.jk1.dependency-license-report plugin
     classpath 'tech.pegasys.internal.license.reporter:license-reporter:1.0.1'
-    classpath 'org.owasp:dependency-check-gradle:7.4.1'
+    classpath 'org.owasp:dependency-check-gradle:7.4.4'
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/ethsigner/blob/master/CONTRIBUTING.md -->

## PR Description
Update dependency-check-gradle plugin to 7.4.4 to fix error updating CVE-2020-36569

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
