### PR TITLE
Upgrade Vertx to 4.3.8

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/tls/ClientSideTlsAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/tls/ClientSideTlsAcceptanceTest.java
@@ -184,7 +184,7 @@ class ClientSideTlsAcceptanceTest {
   }
 
   @Test
-  void missingKeyStoreForEthSignerResultsInEthSignerTerminating(@TempDir Path workDir)
+  void missingKeyStoreForEthSignerResultsInInternalServerError500Return(@TempDir Path workDir)
       throws Exception {
     final TlsCertificateDefinition missingServerCert =
         new TlsCertificateDefinition(
@@ -210,8 +210,8 @@ class ClientSideTlsAcceptanceTest {
   }
 
   @Test
-  void incorrectPasswordForDownstreamKeyStoreResultsInEthSignerTerminating(@TempDir Path workDir)
-      throws Exception {
+  void incorrectPasswordForDownstreamKeyStoreResultsInInternalServerError500Return(
+      @TempDir Path workDir) throws Exception {
     final TlsCertificateDefinition serverPresentedCertWithInvalidPassword =
         TlsCertificateDefinition.loadFromResource("tls/cert1.pfx", "wrong_password");
     final TlsCertificateDefinition serverCert =

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/tls/support/TlsEnabledHttpServerFactory.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/tls/support/TlsEnabledHttpServerFactory.java
@@ -85,8 +85,8 @@ public class TlsEnabledHttpServerFactory {
       router
           .route(HttpMethod.POST, "/")
           .produces(HttpHeaderValues.APPLICATION_JSON.toString())
-          .handler(BodyHandler.create())
           .handler(ResponseContentTypeHandler.create())
+          .handler(BodyHandler.create())
           .failureHandler(new JsonRpcErrorHandler(new HttpResponseFactory()))
           .handler(new JsonRpcHandler(null, requestMapper, jsonDecoder));
 

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/AllDomainsCorsIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/AllDomainsCorsIntegrationTest.java
@@ -17,7 +17,6 @@ import static org.mockserver.model.HttpRequest.request;
 
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.Optional;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.json.Json;
@@ -61,8 +60,7 @@ public class AllDomainsCorsIntegrationTest extends IntegrationTestBase {
 
     sendPostRequestAndVerifyResponse(
         request.ethSigner(requestHeaders, netVersionRequest),
-        response.ethSigner(
-            HttpResponseStatus.FORBIDDEN, Optional.of("403 CORS Rejected - Invalid origin")));
+        response.ethSigner(HttpResponseStatus.FORBIDDEN, "403 CORS Rejected - Invalid origin"));
 
     // Cors headers should not be forwarded to the downstream web3 provider (CORS is handled
     // entirely within Ethsigner.

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/AllDomainsCorsIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/AllDomainsCorsIntegrationTest.java
@@ -12,15 +12,14 @@
  */
 package tech.pegasys.ethsigner.jsonrpcproxy;
 
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockserver.model.HttpRequest.request;
 
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 
-import com.google.common.collect.Lists;
-import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.json.Json;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.BeforeAll;
@@ -31,9 +30,6 @@ import org.web3j.protocol.core.Response;
 import org.web3j.protocol.core.methods.response.NetVersion;
 
 public class AllDomainsCorsIntegrationTest extends IntegrationTestBase {
-
-  private static final Iterable<Entry<String, String>> RESPONSE_HEADERS =
-      singletonList(ImmutablePair.of("Content-Type", "Application/Json"));
 
   private static final String ROOT_PATH = "/arbitraryRootPath";
 
@@ -52,15 +48,10 @@ public class AllDomainsCorsIntegrationTest extends IntegrationTestBase {
     final String netVersionRequest = Json.encode(jsonRpc().netVersion());
     final Response<String> netVersion = new NetVersion();
     netVersion.setResult("4");
-    final String netVersionResponse = Json.encode(netVersion);
 
+    // Vertx 4.3.8 returns 403 Forbidden status with CORS rejected in status line.
     setUpEthNodeResponse(
-        request.ethNode(netVersionRequest), response.ethNode(RESPONSE_HEADERS, netVersionResponse));
-
-    final List<Entry<String, String>> expectedResponseHeaders =
-        Lists.newArrayList(RESPONSE_HEADERS);
-    expectedResponseHeaders.add(
-        ImmutablePair.of(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), originDomain));
+        request.ethNode(netVersionRequest), response.ethNode("", HttpResponseStatus.FORBIDDEN));
 
     final Iterable<Entry<String, String>> requestHeaders =
         List.of(
@@ -70,7 +61,8 @@ public class AllDomainsCorsIntegrationTest extends IntegrationTestBase {
 
     sendPostRequestAndVerifyResponse(
         request.ethSigner(requestHeaders, netVersionRequest),
-        response.ethSigner(expectedResponseHeaders, netVersionResponse));
+        response.ethSigner(
+            HttpResponseStatus.FORBIDDEN, Optional.of("403 CORS Rejected - Invalid origin")));
 
     // Cors headers should not be forwarded to the downstream web3 provider (CORS is handled
     // entirely within Ethsigner.

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -321,6 +321,9 @@ public class IntegrationTestBase {
   private void verifyResponseMatchesExpected(
       final Response response, final EthSignerResponse expectResponse) {
     assertThat(response.statusCode()).isEqualTo(expectResponse.getStatusCode());
+    if (expectResponse.getStatusLine().isPresent()) {
+      assertThat(response.getStatusLine()).contains(expectResponse.getStatusLine().get());
+    }
     assertThat(response.headers())
         .containsAll(RestAssuredConverter.headers(expectResponse.getHeaders()));
     assertThat(response.body().print()).isEqualTo(expectResponse.getBody());

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/model/response/EthResponseFactory.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/model/response/EthResponseFactory.java
@@ -18,7 +18,6 @@ import tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError;
 import tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcErrorResponse;
 
 import java.util.Map.Entry;
-import java.util.Optional;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.json.Json;
@@ -55,8 +54,7 @@ public class EthResponseFactory {
     return new EthSignerResponse(NO_HEADERS, body, statusCode);
   }
 
-  public EthSignerResponse ethSigner(
-      final HttpResponseStatus statusCode, Optional<String> statusLine) {
+  public EthSignerResponse ethSigner(final HttpResponseStatus statusCode, String statusLine) {
     return new EthSignerResponse(NO_HEADERS, "", statusCode, statusLine);
   }
 

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/model/response/EthResponseFactory.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/model/response/EthResponseFactory.java
@@ -18,6 +18,7 @@ import tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError;
 import tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcErrorResponse;
 
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.json.Json;
@@ -52,6 +53,11 @@ public class EthResponseFactory {
 
   public EthSignerResponse ethSigner(final String body, final HttpResponseStatus statusCode) {
     return new EthSignerResponse(NO_HEADERS, body, statusCode);
+  }
+
+  public EthSignerResponse ethSigner(
+      final HttpResponseStatus statusCode, Optional<String> statusLine) {
+    return new EthSignerResponse(NO_HEADERS, "", statusCode, statusLine);
   }
 
   public EthNodeResponse ethNode(final Iterable<Entry<String, String>> headers, final String body) {

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/model/response/EthSignerResponse.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/model/response/EthSignerResponse.java
@@ -32,20 +32,14 @@ public class EthSignerResponse {
       final Iterable<Entry<String, String>> headers,
       final JsonRpcResponse body,
       final HttpResponseStatus status) {
-    this.body = Json.encode(body);
-    this.headers = headers;
-    this.status = status;
-    this.statusLine = Optional.empty();
+    this(headers, Json.encode(body), status, null);
   }
 
   public EthSignerResponse(
       final Iterable<Entry<String, String>> headers,
       final String body,
       final HttpResponseStatus status) {
-    this.body = body;
-    this.headers = headers;
-    this.status = status;
-    this.statusLine = Optional.empty();
+    this(headers, body, status, null);
   }
 
   public EthSignerResponse(

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/model/response/EthSignerResponse.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/model/response/EthSignerResponse.java
@@ -52,11 +52,11 @@ public class EthSignerResponse {
       final Iterable<Entry<String, String>> headers,
       final String body,
       final HttpResponseStatus status,
-      Optional<String> statusLine) {
+      final String statusLine) {
     this.body = body;
     this.headers = headers;
     this.status = status;
-    this.statusLine = statusLine;
+    this.statusLine = Optional.ofNullable(statusLine);
   }
 
   public String getBody() {

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/model/response/EthSignerResponse.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/model/response/EthSignerResponse.java
@@ -15,6 +15,7 @@ package tech.pegasys.ethsigner.jsonrpcproxy.model.response;
 import tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcResponse;
 
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.json.Json;
@@ -25,6 +26,8 @@ public class EthSignerResponse {
   private final Iterable<Entry<String, String>> headers;
   private final HttpResponseStatus status;
 
+  private final Optional<String> statusLine;
+
   public EthSignerResponse(
       final Iterable<Entry<String, String>> headers,
       final JsonRpcResponse body,
@@ -32,6 +35,7 @@ public class EthSignerResponse {
     this.body = Json.encode(body);
     this.headers = headers;
     this.status = status;
+    this.statusLine = Optional.empty();
   }
 
   public EthSignerResponse(
@@ -41,6 +45,18 @@ public class EthSignerResponse {
     this.body = body;
     this.headers = headers;
     this.status = status;
+    this.statusLine = Optional.empty();
+  }
+
+  public EthSignerResponse(
+      final Iterable<Entry<String, String>> headers,
+      final String body,
+      final HttpResponseStatus status,
+      Optional<String> statusLine) {
+    this.body = body;
+    this.headers = headers;
+    this.status = status;
+    this.statusLine = statusLine;
   }
 
   public String getBody() {
@@ -53,5 +69,9 @@ public class EthSignerResponse {
 
   public int getStatusCode() {
     return status.code();
+  }
+
+  public Optional<String> getStatusLine() {
+    return statusLine;
   }
 }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
@@ -136,8 +136,8 @@ public class Runner {
     router
         .route(HttpMethod.POST, "/")
         .produces(JSON)
-        .handler(BodyHandler.create())
         .handler(ResponseContentTypeHandler.create())
+        .handler(BodyHandler.create())
         .failureHandler(new JsonRpcErrorHandler(new HttpResponseFactory()))
         .blockingHandler(new JsonRpcHandler(responseFactory, requestMapper, jsonDecoder), false);
 
@@ -145,8 +145,8 @@ public class Runner {
     router
         .route(HttpMethod.GET, "/upcheck")
         .produces(TEXT)
-        .handler(BodyHandler.create())
         .handler(ResponseContentTypeHandler.create())
+        .handler(BodyHandler.create())
         .failureHandler(new LogErrorHandler())
         .handler(new UpcheckHandler());
 

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
@@ -130,7 +130,8 @@ public class Runner {
     router
         .route()
         .handler(
-            CorsHandler.create(buildCorsRegexFromConfig())
+            CorsHandler.create()
+                .addRelativeOrigin(buildCorsRegexFromConfig())
                 .allowedHeaders(Sets.newHashSet("*", "content-type")));
 
     router

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -30,7 +30,7 @@ dependencyManagement {
 
     dependency 'io.rest-assured:rest-assured:4.4.0'
 
-    dependencySet(group: 'io.vertx', version: '4.2.7') {
+    dependencySet(group: 'io.vertx', version: '4.3.8') {
        entry 'vertx-codegen'
        entry 'vertx-core'
        entry 'vertx-unit'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/ethsigner/blob/master/CONTRIBUTING.md -->

## PR Description
Upgrade Vertx to 4.3.8
 - Fix vertx handler order
 - Fix CORS integration tests
 - Fixing TLS AT. Vertx does not validate keystores at initialization time anymore, it validates them lazily instead.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#485 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
