### PR TITLE
Fetch latest libc6 and libc-bin in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
-RUN apt update && apt install -y --no-install-recommends libc-bin libc6 libssl3 curl iputils-ping net-tools netcat \
+RUN apt update && apt install -y --no-install-recommends libc-bin libc6 curl iputils-ping net-tools netcat \
  && apt clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
-RUN apt update && apt install -y --no-install-recommends libssl3 curl iputils-ping net-tools netcat \
+RUN apt update && apt install -y --no-install-recommends libc-bin libc6 libssl3 curl iputils-ping net-tools netcat \
  && apt clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/ethsigner/blob/master/CONTRIBUTING.md -->

## PR Description
Fetch latest libc6 and libc-bin (which would resolve to version 2.35-0ubuntu3.4) in docker image to fix trivy reported vulnerability in above libraries.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
