### PR TITLE
Use Java 17 and upgrade Azure and web3j libraries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   executor_med:  # 2cpu, 4G ram
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:17.0
         auth:
           username: $DOCKER_USER_RO
           password: $DOCKER_PASSWORD_RO             
@@ -19,7 +19,7 @@ executors:
 
   executor_large: # 4cpu, 8G ram
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:17.0
         auth:
           username: $DOCKER_USER_RO
           password: $DOCKER_PASSWORD_RO     
@@ -154,8 +154,7 @@ jobs:
     executor: executor_med
     steps:
       - prepare
-      - setup_remote_docker:
-          version: 20.10.11
+      - setup_remote_docker
       - attach_workspace:
           at: ~/project
       - run:
@@ -190,8 +189,7 @@ jobs:
     executor: executor_med
     steps:
       - prepare
-      - setup_remote_docker:
-          version: 20.10.11
+      - setup_remote_docker
       - attach_workspace:
           at: ~/project
       - run:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -20,8 +20,11 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - name: Build an image from Dockerfile
         run: |
           ./gradlew --no-daemon --parallel build -x test distDocker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Features Added
 - Build and docker image to use Java 17
 - Updated Docker image to use the latest Ubuntu LTS image
+- Updated web3j library to 4.10.2
 
 ### Bugs Fixed
 - Update grpc to version 1.57.2 to fix CVE-2023-33953

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 - Update grpc to version 1.57.2 to fix CVE-2023-33953
 - Update Azure libraries to fix CVE-2023-36415
-- Update web3j core to 4.10.3 to fix okhttp logging interceptor version to fix CVE-2023-0833
+- Update okhttp logging interceptor version to fix CVE-2023-0833
 
 ## 23.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 ## Next release
 
 ## Features Added
+- Build and docker image to use Java 17
 - Updated Docker image to use the latest Ubuntu LTS image
 
 ### Bugs Fixed
 - Update grpc to version 1.57.2 to fix CVE-2023-33953
+- Update Azure libraries to fix CVE-2023-36415
+- Update web3j core to 4.10.3 to fix okhttp logging interceptor version to fix CVE-2023-0833
 
 ## 23.6.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
 }
 
 plugins {
-  id 'com.diffplug.spotless' version '6.2.0'
+  id 'com.diffplug.spotless' version '6.22.0'
   id 'com.github.jk1.dependency-license-report' version '2.0'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'me.champeau.gradle.jmh' version '0.5.3' apply false
@@ -43,8 +43,8 @@ String repositoryName = projectName.toLowerCase()
 String projectHome = projectName.toUpperCase() + "_HOME"
 
 
-if (!JavaVersion.current().java11Compatible) {
-  throw new GradleException("Java 11 or later is required to build " + projectName + ".\n" +
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+  throw new GradleException("Java 17 or later is required to build Web3Signer.\n" +
   "  Detected version ${JavaVersion.current()}")
 }
 
@@ -115,8 +115,8 @@ allprojects {
     from javadoc.destinationDir
   }
 
-  sourceCompatibility = 11
-  targetCompatibility = 11
+  sourceCompatibility = 17
+  targetCompatibility = 17
 
   repositories {
     mavenCentral()
@@ -135,7 +135,7 @@ allprojects {
         exclude '**/.gradle/**'
       }
       removeUnusedImports()
-      googleJavaFormat('1.7')
+      googleJavaFormat('1.10.0')
       importOrder 'tech.pegasys', 'java', ''
       trimTrailingWhitespace()
       endWithNewline()
@@ -250,7 +250,6 @@ allprojects {
     options.addStringOption('Xwerror', '-html5')
     options.encoding = 'UTF-8'
   }
-
 }
 
 task deploy() {}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11 as jre-build
+FROM eclipse-temurin:17 as jre-build
 
 # Create a custom Java runtime
 RUN JAVA_TOOL_OPTIONS="-Djdk.lang.Process.launchMechanism=vfork" "$JAVA_HOME/bin/jlink" \

--- a/ethsigner/core/build.gradle
+++ b/ethsigner/core/build.gradle
@@ -69,7 +69,6 @@ dependencies {
   integrationTestImplementation 'org.mockito:mockito-core'
   integrationTestImplementation 'org.mockito:mockito-junit-jupiter'
   integrationTestImplementation 'org.awaitility:awaitility'
-  integrationTestImplementation 'org.web3j:crypto'
 
   integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/ethsigner/core/build.gradle
+++ b/ethsigner/core/build.gradle
@@ -69,6 +69,7 @@ dependencies {
   integrationTestImplementation 'org.mockito:mockito-core'
   integrationTestImplementation 'org.mockito:mockito-junit-jupiter'
   integrationTestImplementation 'org.awaitility:awaitility'
+  integrationTestImplementation 'org.web3j:crypto'
 
   integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/util/ByteUtils.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/util/ByteUtils.java
@@ -19,7 +19,7 @@ public class ByteUtils {
   /**
    * Omitting sign indication byte. <br>
    * <br>
-   * Instead of {@link org.bouncycastle.util.BigIntegers#asUnsignedByteArray(BigInteger)} <br>
+   * Instead of org.bouncycastle.util.BigIntegers#asUnsignedByteArray(BigInteger) <br>
    * we use this custom method to avoid an empty array in case of BigInteger.ZERO
    *
    * @param value - any big integer number. A <code>null</code>-value will return <code>null</code>

--- a/gradle/owasp-suppression.xml
+++ b/gradle/owasp-suppression.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <!-- See https://jeremylong.github.io/DependencyCheck/general/suppression.html for examples -->
+    <suppress until="2023-12-16">
+        <notes><![CDATA[
+        Suppress CVE-2023-36415 as this should only be applicable on version up to but excluding 1.10.2.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.azure/azure\-identity@1\.10\.[2-9]$</packageUrl>
+        <vulnerabilityName>CVE-2023-36415</vulnerabilityName>
+    </suppress>
     <suppress until="2023-12-12">
         <notes><![CDATA[
         Temporary suppression, as it's arguably a false positive: https://github.com/netty/netty/issues/8537#issuecomment-1527896917

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -74,10 +74,11 @@ dependencyManagement {
       entry 'mockito-junit-jupiter'
     }
 
-    dependencySet(group: 'org.web3j', version: '4.9.4') {
+    dependencySet(group: 'org.web3j', version: '4.10.2') {
       entry 'besu'
       entry ('core') {
         exclude group: 'com.github.jnr', name: 'jnr-unixsocket'
+        exclude group: 'org.bouncycastle', name: 'bcprov-jdk15on'
       }
       entry ('crypto') {
         exclude group: 'org.bouncycastle', name: 'bcprov-jdk15on'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -23,6 +23,11 @@ dependencyManagement {
     dependency 'com.google.guava:guava:32.0.1-jre'
 
     dependency 'com.squareup.okhttp3:okhttp:4.11.0'
+    /*
+    com.squareup.okhttp3:logging-interceptor:4.9.0 // CVE-2023-0833
+      \--- org.web3j:core:4.10.2
+    */
+    dependency 'com.squareup.okhttp3:logging-interceptor:4.11.0'
 
     dependency 'commons-io:commons-io:2.11.0'
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -74,7 +74,7 @@ dependencyManagement {
       entry 'mockito-junit-jupiter'
     }
 
-    dependencySet(group: 'org.web3j', version: '4.10.2') {
+    dependencySet(group: 'org.web3j', version: '4.10.3') {
       entry 'besu'
       entry ('core') {
         exclude group: 'com.github.jnr', name: 'jnr-unixsocket'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -74,7 +74,7 @@ dependencyManagement {
       entry 'mockito-junit-jupiter'
     }
 
-    dependencySet(group: 'org.web3j', version: '4.10.3') {
+    dependencySet(group: 'org.web3j', version: '4.10.2') {
       entry 'besu'
       entry ('core') {
         exclude group: 'com.github.jnr', name: 'jnr-unixsocket'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -129,6 +129,14 @@ dependencyManagement {
       entry 'netty-resolver-dns'
     }
 
+    //overriding Azure libraries dependencies as we don't update signers library anymore
+    dependencySet(group: 'com.azure', version: '4.7.0') {
+      entry 'azure-security-keyvault-secrets'
+      entry 'azure-security-keyvault-keys'
+    }
+    dependency 'com.azure:azure-identity:1.10.3'
+    dependency 'com.azure:azure-core-http-netty:1.13.8'
+
     /*
       io.projectreactor.netty:reactor-netty-core:1.0.15 // CVE-2022-31684
       \--- io.projectreactor.netty:reactor-netty-http:1.0.15


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/ethsigner/blob/master/CONTRIBUTING.md -->
## PR Description
- Use Java 17 to build and at runtime. Update docker image to use Java 17.
- Upgrade Azure libraries to fix CVE-2023-36415. Suppress CVE for azure-identity 1.10.2 to 1.10.9 as it is only applicable on 1.10.1 and lower.
- Upgrade web3j core to 4.10.2
- Override logging-interceptor which fixes okhttp3 dependency for CVE-2023-0833. 
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
