### PR TITLE
Do not fail gradle javadoc task on javadoc comments warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,8 +246,7 @@ allprojects {
   }
 
   javadoc {
-    options.addStringOption('Xdoclint:all', '-quiet')
-    options.addStringOption('Xwerror', '-html5')
+    options.addBooleanOption('Xdoclint:all', true)
     options.encoding = 'UTF-8'
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/ethsigner/blob/master/CONTRIBUTING.md -->
## PR Description
Java 17 enforces several javadoc comments warnings which results in EthSigner javadoc task to be failed (called during `publish` task). This PR updates javadoc task to not fail on reported javadoc comments warnings.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
