### PR TITLE
Dependency check upgrade and suppress FP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,8 +111,9 @@ jobs:
             ./gradlew --no-daemon --parallel build
       - run:
           name: Dependency vulnerability scan
+          no_output_timeout: 40m
           command: |
-            ./gradlew --no-daemon -Dorg.gradle.parallel=false dependencyCheckAggregate
+            ./gradlew --no-daemon -Dorg.gradle.parallel=false dependencyCheckAggregate -DnvdApiDelay=6000
       - run:
           name: Test
           no_output_timeout: 20m

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
   dependencies {
     // custom license-reporter used by com.github.jk1.dependency-license-report plugin
     classpath 'tech.pegasys.internal.license.reporter:license-reporter:1.0.1'
-    classpath 'org.owasp:dependency-check-gradle:8.4.2'
+    classpath 'org.owasp:dependency-check-gradle:9.0.2'
   }
 }
 

--- a/gradle/owasp-suppression.xml
+++ b/gradle/owasp-suppression.xml
@@ -37,4 +37,18 @@
         ]]></notes>
         <cve>CVE-2020-8908</cve>
     </suppress>
+    <suppress until="2024-01-16">
+        <notes><![CDATA[
+        FP per issue #6100 - CVE-2023-36052 since it is related to Azure-cli not to the azure-core libraries
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.azure/azure*@*.*$</packageUrl>
+        <cve>CVE-2023-36052</cve>
+    </suppress>
+    <suppress until="2024-01-16">
+        <notes><![CDATA[
+        CVE relates to attach on gRPC servers (not clients) and is dependent on the Netty version used
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.grpc/grpc\-.*$</packageUrl>
+        <cve>CVE-2023-44487</cve>
+    </suppress>
 </suppressions>

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -102,7 +102,7 @@ dependencyManagement {
     dependency "org.hyperledger.besu.internal:metrics-core:${besuVersion}"
 
     // explicit declaring to override transitive dependencies with vulnerabilities
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.16.0'
     dependencySet(group: 'com.google.protobuf', version: '3.21.12') {
       /*
         com.google.protobuf:protobuf-java:3.11.4 -> 3.21.9 // CVE-2022-3509
@@ -112,7 +112,7 @@ dependencyManagement {
       entry 'protobuf-java'
       entry 'protobuf-java-util'
     }
-    dependencySet(group: 'io.grpc', version: '1.59.0') {
+    dependencySet(group: 'io.grpc', version: '1.59.1') {
       entry 'grpc-api'
       entry 'grpc-context'
       entry 'grpc-core'
@@ -128,7 +128,7 @@ dependencyManagement {
       entry 'kotlin-stdlib-jdk8'
     }
     // addressing CVE-2023-44487
-    dependencySet(group: 'io.netty', version: '4.1.100.Final') {
+    dependencySet(group: 'io.netty', version: '4.1.101.Final') {
       entry 'netty-all'
       entry 'netty-codec-http2'
       entry 'netty-handler-proxy'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/ethsigner/blob/master/CONTRIBUTING.md -->

## PR Description
Based on web3signer PR https://github.com/Consensys/web3signer/pull/951

This PR upgrades the dependency check version and adds a suppression to a false positive to the azure-core libraries not related to the Azure CLI CVE reported. Already has an issue raised in https://github.com/jeremylong/DependencyCheck/issues/6100

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
