### PR TITLE
Override nimbus-jose-jwt version to avoid CVE-2023-52428

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -157,7 +157,7 @@ dependencyManagement {
      */
     dependency 'commons-net:commons-net:3.9.0'
 
-    // manual overriding of json-smart and nimbus-jost-kwt to avoid CVE-2023-1370
+    // manual overriding of json-smart to avoid CVE-2023-1370
     /*
      +--- com.azure:azure-identity -> 1.8.1
      |    +--- com.microsoft.azure:msal4j:1.13.5
@@ -167,7 +167,15 @@ dependencyManagement {
      */
 
     dependency 'net.minidev:json-smart:2.4.10'
-    dependency 'com.nimbusds:nimbus-jose-jwt:9.31'
+    
+    // manual overriding of nimbus-jose-jwt to avoid CVE-2023-52428
+    /*
+    com.nimbusds:nimbus-jose-jwt:9.30.2 -> 9.31
+    \--- com.nimbusds:oauth2-oidc-sdk:10.7.1
+         \--- com.microsoft.azure:msal4j:1.14.0
+              +--- com.azure:azure-identity:1.11.1
+     */
+    dependency 'com.nimbusds:nimbus-jose-jwt:9.37.3'
 
     // addresses CVE-2023-3635
     dependency 'com.squareup.okio:okio:3.4.0'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/ethsigner/blob/master/CONTRIBUTING.md -->

## PR Description
Override nimbus-jose-jwt version to avoid CVE-2023-52428

```
./gradlew --no-daemon -Dorg.gradle.parallel=false dependencyCheckAggregate
To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.6/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build

> Task :dependencyCheckAggregate
Verifying dependencies for project ethsigner
Checking for updates and analyzing dependencies for vulnerabilities

<SNIP>
BUILD SUCCESSFUL in 40s
```
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.
